### PR TITLE
Updated Payment with Order

### DIFF
--- a/services/payment/src/EShopOnAbp.PaymentService.Application.Contracts/PaymentRequests/PaymentRequestCreationDto.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.Application.Contracts/PaymentRequests/PaymentRequestCreationDto.cs
@@ -11,8 +11,12 @@ namespace EShopOnAbp.PaymentService.PaymentRequests
         [MaxLength(PaymentRequestConsts.MaxCurrencyLength)]
         public string Currency { get; set; }
 
-        public string BuyerId { get; set; }
+        [Required]
+        [MinLength(PaymentRequestConsts.MinOrderIdLength)]
+        [MaxLength(PaymentRequestConsts.MaxOrderIdLength)]
+        public string OrderId { get; set; }
 
+        public string BuyerId { get; set; }
         public List<PaymentRequestProductCreationDto> Products { get; set; }
     }
 }

--- a/services/payment/src/EShopOnAbp.PaymentService.Application.Contracts/PaymentRequests/PaymentRequestDto.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.Application.Contracts/PaymentRequests/PaymentRequestDto.cs
@@ -12,6 +12,8 @@ namespace EShopOnAbp.PaymentService.PaymentRequests
         [MaxLength(PaymentRequestConsts.MaxCurrencyLength)] 
         public string Currency { get; set; }
 
+        public string OrderId { get; set; }
+        
         public string BuyerId { get; set; }
 
         public bool IsDeleted { get; set; }

--- a/services/payment/src/EShopOnAbp.PaymentService.Application.Contracts/PaymentRequests/PaymentRequestProduct.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.Application.Contracts/PaymentRequests/PaymentRequestProduct.cs
@@ -3,13 +3,14 @@ using Volo.Abp.Application.Dtos;
 
 namespace EShopOnAbp.PaymentService.PaymentRequests
 {
-    [Serializable]
     public class PaymentRequestProductDto : EntityDto<Guid>
     {
         public Guid PaymentRequestId { get; private set; }
 
         public string ReferenceId { get; set; }
-
+        
+        public string Code { get; set; }
+        
         public string Name { get; set; }
 
         public decimal UnitPrice { get; set; }

--- a/services/payment/src/EShopOnAbp.PaymentService.Application.Contracts/PaymentRequests/PaymentRequestProductCreationDto.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.Application.Contracts/PaymentRequests/PaymentRequestProductCreationDto.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace EShopOnAbp.PaymentService.PaymentRequests
 {
@@ -7,12 +8,15 @@ namespace EShopOnAbp.PaymentService.PaymentRequests
     {
         public string ReferenceId { get; set; }
 
+        [Required]
+        [MaxLength(PaymentRequestConsts.MaxCodeLength)]
+        public string Code { get; set; }
+
+        [Required]
+        [MaxLength(PaymentRequestConsts.MaxNameLength)]
         public string Name { get; set; }
-
         public decimal UnitPrice { get; set; }
-
         public int Quantity { get; set; }
-
         public decimal TotalPrice { get; set; }
     }
 }

--- a/services/payment/src/EShopOnAbp.PaymentService.Application/PaymentRequests/PaymentRequestAppService.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.Application/PaymentRequests/PaymentRequestAppService.cs
@@ -27,17 +27,18 @@ namespace EShopOnAbp.PaymentService.PaymentRequests
 
         public virtual async Task<PaymentRequestDto> CreateAsync(PaymentRequestCreationDto input)
         {
-            var paymentRequest = new PaymentRequest(GuidGenerator.Create(), input.Currency, input.BuyerId);
+            var paymentRequest = new PaymentRequest(id: GuidGenerator.Create(), orderId: input.OrderId, currency: input.Currency, buyerId: input.BuyerId);
 
             foreach (var paymentRequestProduct in input.Products
                 .Select(s => new PaymentRequestProduct(
                     GuidGenerator.Create(),
-                    paymentRequest.Id,
-                    s.Name,
-                    s.UnitPrice,
-                    s.Quantity,
-                    s.TotalPrice,
-                    s.ReferenceId)))
+                    paymentRequestId: paymentRequest.Id,
+                    code: s.Code,
+                    name: s.Name,
+                    unitPrice: s.UnitPrice,
+                    quantity: s.Quantity,
+                    totalPrice: s.TotalPrice,
+                    referenceId: s.ReferenceId)))
             {
                 paymentRequest.Products.Add(paymentRequestProduct);
             }

--- a/services/payment/src/EShopOnAbp.PaymentService.Domain.Shared/PaymentRequests/PaymentRequestCompletedEto.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.Domain.Shared/PaymentRequests/PaymentRequestCompletedEto.cs
@@ -6,20 +6,15 @@ using Volo.Abp.EventBus;
 
 namespace EShopOnAbp.PaymentService.PaymentRequests
 {
-    [Serializable]
     [EventName("EShopOnAbp.Payment.Completed")]
     public class PaymentRequestCompletedEto : EtoBase, IHasExtraProperties
     {
         public Guid PaymentRequestId { get; set; }
-
+        public string OrderId { get; set; }
         public string Currency { get; set; }
-
         public string BuyerId { get; set; }
-
         public PaymentRequestState State { get; set; }
-
         public ICollection<PaymentRequestProductEto> Products { get; set; } = new List<PaymentRequestProductEto>();
-
         public ExtraPropertyDictionary ExtraProperties { get; set; }
     }
 }

--- a/services/payment/src/EShopOnAbp.PaymentService.Domain.Shared/PaymentRequests/PaymentRequestConsts.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.Domain.Shared/PaymentRequests/PaymentRequestConsts.cs
@@ -3,5 +3,9 @@
     public static class PaymentRequestConsts
     {
         public const int MaxCurrencyLength = 3;
+        public const int MinOrderIdLength = 36;
+        public const int MaxOrderIdLength = 36;
+        public const int MaxCodeLength = 32;
+        public const int MaxNameLength = 256;
     }
 }

--- a/services/payment/src/EShopOnAbp.PaymentService.Domain.Shared/PaymentRequests/PaymentRequestFailedEto.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.Domain.Shared/PaymentRequests/PaymentRequestFailedEto.cs
@@ -3,13 +3,14 @@ using Volo.Abp.Data;
 using Volo.Abp.Domain.Entities.Events.Distributed;
 using Volo.Abp.EventBus;
 
-namespace EShopOnAbp.PaymentService
+namespace EShopOnAbp.PaymentService.PaymentRequests
 {
-    [Serializable]
     [EventName("EShopOnAbp.Payment.Completed")]
     public class PaymentRequestFailedEto : EtoBase, IHasExtraProperties
     {
         public Guid PaymentRequestId { get; set; }
+        
+        public string OrderId { get; set; }
         public string FailReason { get; set; }
         public ExtraPropertyDictionary ExtraProperties { get; set; }
     }

--- a/services/payment/src/EShopOnAbp.PaymentService.Domain.Shared/PaymentRequests/PaymentRequestProductEto.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.Domain.Shared/PaymentRequests/PaymentRequestProductEto.cs
@@ -6,13 +6,10 @@ namespace EShopOnAbp.PaymentService.PaymentRequests
     public class PaymentRequestProductEto
     {
         public string ReferenceId { get; set; }
-
+        public string Code { get; set; }
         public string Name { get; set; }
-
         public decimal UnitPrice { get; set; }
-
         public int Quantity { get; set; }
-
         public decimal TotalPrice { get; set; }
     }
 }

--- a/services/payment/src/EShopOnAbp.PaymentService.Domain/PaymentRequests/PaymentRequest.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.Domain/PaymentRequests/PaymentRequest.cs
@@ -43,6 +43,7 @@ namespace EShopOnAbp.PaymentService.PaymentRequests
             AddDistributedEvent(new PaymentRequestCompletedEto
             {
                 PaymentRequestId = Id,
+                OrderId = OrderId,
                 BuyerId = BuyerId,
                 Currency = Currency,
                 State = State,
@@ -64,6 +65,7 @@ namespace EShopOnAbp.PaymentService.PaymentRequests
             AddDistributedEvent(new PaymentRequestFailedEto
             {
                 PaymentRequestId = Id,
+                OrderId = OrderId,
                 FailReason = failReason,
                 ExtraProperties = ExtraProperties
             });
@@ -73,7 +75,7 @@ namespace EShopOnAbp.PaymentService.PaymentRequests
         {
             return new PaymentRequestProductEto
             {
-                Code= product.Code,
+                Code = product.Code,
                 Name = product.Name,
                 Quantity = product.Quantity,
                 ReferenceId = product.ReferenceId,

--- a/services/payment/src/EShopOnAbp.PaymentService.Domain/PaymentRequests/PaymentRequest.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.Domain/PaymentRequests/PaymentRequest.cs
@@ -9,29 +9,23 @@ namespace EShopOnAbp.PaymentService.PaymentRequests
 {
     public class PaymentRequest : CreationAuditedAggregateRoot<Guid>, ISoftDelete
     {
-        [NotNull]
-        public string Currency { get; protected set; }
-
-        [CanBeNull]
-        public string BuyerId { get; protected set; }
-
+        [NotNull] public string Currency { get; protected set; }
+        [NotNull] public string OrderId { get; protected set; }
+        [CanBeNull] public string BuyerId { get; protected set; }
         public PaymentRequestState State { get; protected set; }
-
-        [CanBeNull]
-        public string FailReason { get; protected set; }
-
+        [CanBeNull] public string FailReason { get; protected set; }
         public bool IsDeleted { get; set; }
-
         public ICollection<PaymentRequestProduct> Products { get; } = new List<PaymentRequestProduct>();
-
         private PaymentRequest()
         {
-
         }
 
-        public PaymentRequest(Guid id, [NotNull] string currency, [CanBeNull] string buyerId = null)
+        public PaymentRequest(Guid id,
+            [NotNull] string orderId,
+            [NotNull] string currency,
+            [CanBeNull] string buyerId = null) : base(id)
         {
-            Id = id;
+            OrderId = Check.NotNullOrWhiteSpace(orderId, nameof(orderId), minLength: PaymentRequestConsts.MinOrderIdLength, maxLength: PaymentRequestConsts.MaxOrderIdLength);
             Currency = Check.NotNullOrWhiteSpace(currency, nameof(currency), maxLength: PaymentRequestConsts.MaxCurrencyLength);
             BuyerId = buyerId;
         }
@@ -79,6 +73,7 @@ namespace EShopOnAbp.PaymentService.PaymentRequests
         {
             return new PaymentRequestProductEto
             {
+                Code= product.Code,
                 Name = product.Name,
                 Quantity = product.Quantity,
                 ReferenceId = product.ReferenceId,

--- a/services/payment/src/EShopOnAbp.PaymentService.Domain/PaymentRequests/PaymentRequestProduct.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.Domain/PaymentRequests/PaymentRequestProduct.cs
@@ -1,5 +1,6 @@
 ﻿using JetBrains.Annotations;
 using System;
+using Volo.Abp;
 using Volo.Abp.Domain.Entities;
 
 namespace EShopOnAbp.PaymentService.PaymentRequests
@@ -7,29 +8,26 @@ namespace EShopOnAbp.PaymentService.PaymentRequests
     public class PaymentRequestProduct : Entity<Guid>
     {
         public Guid PaymentRequestId { get; private set; }
-
         public string ReferenceId { get; set; }
-
+        public string Code { get; set; }
         public string Name { get; set; }
-
         public decimal UnitPrice { get; set; }
-
         public int Quantity { get; set; }
-
         public decimal TotalPrice { get; set; }
 
         public PaymentRequestProduct(
             Guid id,
             Guid paymentRequestId,
+            [NotNull] string code,
             [NotNull] string name,
             decimal unitPrice,
             int quantity,
             decimal totalPrice,
-            [CanBeNull] string referenceId = null)
+            [CanBeNull] string referenceId = null) : base(id)
         {
-            Id = id;
             PaymentRequestId = paymentRequestId;
-            Name = name;
+            Code = Check.NotNullOrEmpty(code, nameof(code));
+            Name = Check.NotNullOrEmpty(name, nameof(name));
             UnitPrice = unitPrice;
             Quantity = quantity;
             TotalPrice = totalPrice;

--- a/services/payment/src/EShopOnAbp.PaymentService.EntityFrameworkCore/EntityFrameworkCore/PaymentServiceDbContextModelCreatingExtensions.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.EntityFrameworkCore/EntityFrameworkCore/PaymentServiceDbContextModelCreatingExtensions.cs
@@ -20,6 +20,30 @@ namespace EShopOnAbp.PaymentService.EntityFrameworkCore
                     .Property(p => p.Currency)
                     .IsRequired()
                     .HasMaxLength(PaymentRequestConsts.MaxCurrencyLength);
+                
+                entity
+                    .Property(p => p.OrderId)
+                    .IsRequired()
+                    .HasMaxLength(PaymentRequestConsts.MaxOrderIdLength);
+                
+                entity.HasIndex(o => o.OrderId);
+            });
+            
+            builder.Entity<PaymentRequestProduct>(entity =>
+            {
+                entity.ConfigureByConvention();
+
+                entity
+                    .Property(p => p.Code)
+                    .IsRequired()
+                    .HasMaxLength(PaymentRequestConsts.MaxCodeLength);
+                
+                entity
+                    .Property(p => p.Name)
+                    .IsRequired()
+                    .HasMaxLength(PaymentRequestConsts.MaxNameLength);
+
+                entity.HasOne<PaymentRequest>().WithMany(q => q.Products).HasForeignKey(fk => fk.PaymentRequestId).IsRequired();
             });
 
         }

--- a/services/payment/src/EShopOnAbp.PaymentService.EntityFrameworkCore/Migrations/20220103210322_Added_OrderId_ProductCode.Designer.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.EntityFrameworkCore/Migrations/20220103210322_Added_OrderId_ProductCode.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EShopOnAbp.PaymentService.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Volo.Abp.EntityFrameworkCore;
@@ -12,9 +13,10 @@ using Volo.Abp.EntityFrameworkCore;
 namespace EShopOnAbp.PaymentService.Migrations
 {
     [DbContext(typeof(PaymentServiceDbContext))]
-    partial class PaymentServiceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220103210322_Added_OrderId_ProductCode")]
+    partial class Added_OrderId_ProductCode
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/payment/src/EShopOnAbp.PaymentService.EntityFrameworkCore/Migrations/20220103210322_Added_OrderId_ProductCode.cs
+++ b/services/payment/src/EShopOnAbp.PaymentService.EntityFrameworkCore/Migrations/20220103210322_Added_OrderId_ProductCode.cs
@@ -1,0 +1,68 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EShopOnAbp.PaymentService.Migrations
+{
+    public partial class Added_OrderId_ProductCode : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "OrderId",
+                table: "PaymentRequests",
+                type: "character varying(36)",
+                maxLength: 36,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PaymentRequestProduct",
+                type: "character varying(256)",
+                maxLength: 256,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Code",
+                table: "PaymentRequestProduct",
+                type: "character varying(32)",
+                maxLength: 32,
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PaymentRequests_OrderId",
+                table: "PaymentRequests",
+                column: "OrderId");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PaymentRequests_OrderId",
+                table: "PaymentRequests");
+
+            migrationBuilder.DropColumn(
+                name: "OrderId",
+                table: "PaymentRequests");
+
+            migrationBuilder.DropColumn(
+                name: "Code",
+                table: "PaymentRequestProduct");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PaymentRequestProduct",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(256)",
+                oldMaxLength: 256);
+        }
+    }
+}


### PR DESCRIPTION
Since we decided to create _order_ with `Order.Placed` status **before** making payment request, I have added order related data and configuration to payment request.

Previous design for refactoring the payment was removing **PaymentRequestItems** all along and adding only **orderId**. However paypal (and propably future payment methods as well) requires total amount and I find it viable and useful to duplicate order product item data in this service.