### PR TITLE
Fix for the error 'relation "AbpPermissionGroups" does not exist'

### DIFF
--- a/services/administration/src/EShopOnAbp.AdministrationService.EntityFrameworkCore/Migrations/20230509155128_Add-Permissions-And-PermissionGroups-Tables.Designer.cs
+++ b/services/administration/src/EShopOnAbp.AdministrationService.EntityFrameworkCore/Migrations/20230509155128_Add-Permissions-And-PermissionGroups-Tables.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using EShopOnAbp.AdministrationService.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Volo.Abp.EntityFrameworkCore;
@@ -12,9 +13,11 @@ using Volo.Abp.EntityFrameworkCore;
 namespace EShopOnAbp.AdministrationService.Migrations
 {
     [DbContext(typeof(AdministrationServiceDbContext))]
-    partial class AdministrationServiceDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230509155128_Add-Permissions-And-PermissionGroups-Tables")]
+    partial class AddPermissionsAndPermissionGroupsTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/services/administration/src/EShopOnAbp.AdministrationService.EntityFrameworkCore/Migrations/20230509155128_Add-Permissions-And-PermissionGroups-Tables.cs
+++ b/services/administration/src/EShopOnAbp.AdministrationService.EntityFrameworkCore/Migrations/20230509155128_Add-Permissions-And-PermissionGroups-Tables.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EShopOnAbp.AdministrationService.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPermissionsAndPermissionGroupsTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "AbpPermissionGroups",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    DisplayName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    ExtraProperties = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AbpPermissionGroups", x => x.Id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "AbpPermissions",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    GroupName = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    Name = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: false),
+                    ParentName = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    DisplayName = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: false),
+                    IsEnabled = table.Column<bool>(type: "boolean", nullable: false),
+                    MultiTenancySide = table.Column<byte>(type: "smallint", nullable: false),
+                    Providers = table.Column<string>(type: "character varying(128)", maxLength: 128, nullable: true),
+                    StateCheckers = table.Column<string>(type: "character varying(256)", maxLength: 256, nullable: true),
+                    ExtraProperties = table.Column<string>(type: "text", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_AbpPermissions", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AbpPermissionGroups_Name",
+                table: "AbpPermissionGroups",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AbpPermissions_GroupName",
+                table: "AbpPermissions",
+                column: "GroupName");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AbpPermissions_Name",
+                table: "AbpPermissions",
+                column: "Name",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "AbpPermissionGroups");
+
+            migrationBuilder.DropTable(
+                name: "AbpPermissions");
+        }
+    }
+}


### PR DESCRIPTION
This is a fix for issue https://github.com/abpframework/eShopOnAbp/issues/168

### How to replicate issue

When clicking on "Add to basket" on the public-web app (https://localhost:44335/), it throws this error:

```
Grpc.Core.RpcException: 'Status(StatusCode="Unavailable", Detail="Error starting gRPC call. HttpRequestException: No connection could be made because the target machine actively refused it. (localhost:81)
```

And the logs for the Catalog microservice has this error:

```
relation "AbpPermissionGroups" does not exist
```

### How this fix was discovered

I learned from [this closed PR](https://github.com/abpframework/eShopOnAbp/pull/161) that the AdministrationService will be updated to fix the `'relation "AbpPermissionGroups" does not exist'` error.

I found out that the update for AdministrationService was done in commit # https://github.com/abpframework/eShopOnAbp/commit/c3aca0f334d7096a038fa9b1d45be737e3bd3820. In this commit, `DbSet` for `PermissionGroups` and `Permissions` were added to `AdministrationServiceDbContext`, but no corresponding migration scripts was added. So I added migration scripts for that and created this PR.





