### PR TITLE
Fix Swagger Authorization and Client Creation

### DIFF
--- a/shared/EShopOnAbp.Keycloak.DbMigrator/KeycloakDataSeeder.cs
+++ b/shared/EShopOnAbp.Keycloak.DbMigrator/KeycloakDataSeeder.cs
@@ -137,7 +137,8 @@ public class KeyCloakDataSeeder : IDataSeedContributor, ITransientDependency
     private async Task CreateClientsAsync()
     {
         await CreatePublicWebClientAsync();
-        await CreateSwaggerClientAsync(); // TODO: Test when Volo.Abp.Swashbuckle v6.0.1 is released (https://github.com/abpframework/abp/pull/14409)
+        await CreateSwaggerClientAsync(clientId: "SwaggerClient", name: "Swagger Client Application");
+        await CreateSwaggerClientAsync(clientId: "WebGateway_Swagger", name: "Web Gateway Swagger Client Application");
         await CreateWebClientAsync();
         await CreateCmskitClientAsync();
         await CreateAdministrationClientAsync();
@@ -286,10 +287,10 @@ public class KeyCloakDataSeeder : IDataSeedContributor, ITransientDependency
         }
     }
 
-    private async Task CreateSwaggerClientAsync()
+    private async Task CreateSwaggerClientAsync(string clientId, string name)
     {
         var swaggerClient =
-            (await _keycloakClient.GetClientsAsync(_keycloakOptions.RealmName, clientId: "SwaggerClient"))
+            (await _keycloakClient.GetClientsAsync(_keycloakOptions.RealmName, clientId: clientId))
             .FirstOrDefault();
 
         if (swaggerClient == null)
@@ -307,8 +308,8 @@ public class KeyCloakDataSeeder : IDataSeedContributor, ITransientDependency
 
             swaggerClient = new Client
             {
-                ClientId = "SwaggerClient",
-                Name = "Swagger Client Application",
+                ClientId = clientId,
+                Name = name,
                 Protocol = "openid-connect",
                 Enabled = true,
                 RedirectUris = new List<string>
@@ -329,6 +330,16 @@ public class KeyCloakDataSeeder : IDataSeedContributor, ITransientDependency
             };
 
             await _keycloakClient.CreateClientAsync(_keycloakOptions.RealmName, swaggerClient);
+
+            // Add Scopes For ClientId
+            await AddOptionalClientScopesAsync(
+                clientId,
+                new List<string>
+                {
+                    "AdministrationService", "IdentityService", "BasketService", "CatalogService",
+                    "OrderingService", "PaymentService", "CmskitService"
+                }
+            );
         }
     }
 

--- a/shared/EShopOnAbp.Shared.Hosting.AspNetCore/SwaggerConfigurationHelper.cs
+++ b/shared/EShopOnAbp.Shared.Hosting.AspNetCore/SwaggerConfigurationHelper.cs
@@ -36,6 +36,9 @@ public static class SwaggerConfigurationHelper
                 options.SwaggerDoc(apiName, new OpenApiInfo { Title = apiTitle, Version = apiVersion });
                 options.DocInclusionPredicate((docName, description) => true);
                 options.CustomSchemaIds(type => type.FullName);
-            });
+            },
+            authorizationEndpoint: "/protocol/openid-connect/auth",
+            tokenEndpoint: "/protocol/openid-connect/token"
+        );
     }
 }


### PR DESCRIPTION
**Issue 1: URL Misconfiguration**

Encountered an issue with Swagger's integration with Keycloak due to misconfigured authorization URLs:

- **Original** Authorization URL: http://localhost:8080/realms/master/connect/authorize
- **Original** Token URL: http://localhost:8080/realms/master/connect/token

**Resolved** the issue by updating the authentication URLs in the **SwaggerConfigurationHelper** class within **AddAbpSwaggerGenWithOAuth**:

- **Updated** Authorization URL: http://localhost:8080/realms/master/protocol/openid-connect/auth
- **Updated** Token URL: http://localhost:8080/realms/master/protocol/openid-connect/token

Code changes:

```
context.Services.AddAbpSwaggerGenWithOAuth(
    authority: authority,
    scopes: scopes,
    options =>
    {
        options.SwaggerDoc(apiName, new OpenApiInfo { Title = apiTitle, Version = apiVersion });
        options.DocInclusionPredicate((docName, description) => true);
        options.CustomSchemaIds(type => type.FullName);
    },
    authorizationEndpoint: "/protocol/openid-connect/auth",
    tokenEndpoint: "/protocol/openid-connect/token"
);
```

**Issue 2: Missing Client and Scopes**

Encountered errors due to missing client configurations and scopes for **WebGateway_Swagger** & **SwaggerClient**  in **KeyCloakDataSeeder** , resulting in:

- Invalid Client: **WebGateway_Swagger** (Invalid parameter: redirect_uri)
- Invalid Scopes: **SwaggerClient** & **WebGateway_Swagger** (Auth Error[invalid_scope]: Invalid+scopes:+AdministrationService..)

**Resolved by:**

- Refactoring the **CreateSwaggerClientAsync** function.
- Adding the **WebGateway_Swagger** client using **CreateSwaggerClientAsync**.
- Adding scopes in **CreateSwaggerClientAsync** for **SwaggerClient** & **WebGateway_Swagger**.


**Testing Done**
- Tested and verified the corrected URLs with Keycloak authentication for successful authorization and token retrieval.
- Tested the added client configurations and scopes to ensure proper functionality.

**Additional Notes**
- No additional changes made to existing functionalities.