### PR TITLE
Staging environment using "latest" image tag

### DIFF
--- a/build/build-images-locally.sh
+++ b/build/build-images-locally.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export IMAGE_TAG="1.1.0"
+export IMAGE_TAG="latest"
 export total=12
 cd ../
 export currentFolder=`pwd`

--- a/build/build-images.ps1
+++ b/build/build-images.ps1
@@ -1,4 +1,4 @@
-param ($version='1.0.0')
+param ($version='latest')
 
 $currentFolder = $PSScriptRoot
 $slnFolder = Join-Path $currentFolder "../"

--- a/build/build-images.sh
+++ b/build/build-images.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-export IMAGE_TAG="1.0.0"
+export IMAGE_TAG="latest"
 export total=12
 cd ../
 export currentFolder=`pwd`

--- a/etc/k8s/eshoponabp/values.st.yaml
+++ b/etc/k8s/eshoponabp/values.st.yaml
@@ -44,7 +44,7 @@ web:
     tlsSecret: eshop-wildcard-tls
   image:
     repository: "eshoponabp/app-web"
-    tag: 1.0.0
+    tag: "latest"
 
 # public-web sub-chart override
 public-web:
@@ -65,7 +65,7 @@ public-web:
     tlsSecret: eshop-wildcard-tls
   image:
     repository: "eshoponabp/app-publicweb"
-    tag: 1.0.0
+    tag: "latest"
 
 # identity-service sub-chart override
 identity:
@@ -108,7 +108,7 @@ identity:
     tlsSecret: eshop-wildcard-tls
   image:
     repository: "eshoponabp/service-identity"
-    tag: 1.0.0
+    tag: "latest"
 
 # administration sub-chart override
 administration:
@@ -137,7 +137,7 @@ administration:
     tlsSecret: eshop-wildcard-tls
   image:
     repository: "eshoponabp/service-administration"
-    tag: 1.0.0
+    tag: "latest"
 
 # gateway-web sub-chart override
 gateway-web:
@@ -158,7 +158,7 @@ gateway-web:
     tlsSecret: eshop-wildcard-tls
   image:
     repository: "eshoponabp/gateway-web"
-    tag: 1.0.0
+    tag: "latest"
   reRoutes:
     identityService:
       url: http://eshop-st-identity:8080
@@ -194,7 +194,7 @@ gateway-web-public:
     tlsSecret: eshop-wildcard-tls
   image:
     repository: "eshoponabp/gateway-web-public"
-    tag: 1.0.0
+    tag: "latest"
   reRoutes:
     identityService:
       url: http://eshop-st-identity:8080
@@ -243,7 +243,7 @@ basket:
     tlsSecret: eshop-wildcard-tls
   image:
     repository: "eshoponabp/service-basket"
-    tag: 1.0.0
+    tag: "latest"
 
 # catalog-service sub-chart override
 catalog:
@@ -273,7 +273,7 @@ catalog:
     tlsSecret: eshop-wildcard-tls
   image:
     repository: "eshoponabp/service-catalog"
-    tag: 1.0.0
+    tag: "latest"
 
 # ordering-service sub-chart override
 ordering:
@@ -298,7 +298,7 @@ ordering:
     tlsSecret: eshop-wildcard-tls
   image:
     repository: "eshoponabp/service-ordering"
-    tag: 1.0.0
+    tag: "latest"
 
 # cmskit-service sub-chart override
 cmskit:
@@ -327,7 +327,7 @@ cmskit:
     tlsSecret: eshop-wildcard-tls
   image:
     repository: "eshoponabp/service-cmskit"
-    tag: 1.0.0
+    tag: "latest"
 
 # payment-service sub-chart override
 payment:
@@ -354,7 +354,7 @@ payment:
     tlsSecret: eshop-wildcard-tls
   image:
     repository: "eshoponabp/service-payment"
-    tag: 1.0.0
+    tag: "latest"
 
 # Default values for eshoponabp.
 # This is a YAML-formatted file.


### PR DESCRIPTION
The default staging environment should use "latest" tag while we can update scripts for deployments to use spesific versions.